### PR TITLE
Added a test of non-FMA Fast Kalman

### DIFF
--- a/src/main/common/filter.c
+++ b/src/main/common/filter.c
@@ -344,3 +344,22 @@ FAST_CODE float fastKalmanUpdate(fastKalman_t *filter, float input)
 
     return filter->x;
 }
+
+FAST_CODE float fastKalmanUpdate2(fastKalman_t *filter, float input)
+{
+    // project the state ahead using acceleration
+    filter->x += (filter->x - filter->lastX);
+
+    // update last state
+    filter->lastX = filter->x;
+
+    // prediction update
+    filter->p = filter->p + filter->q;
+
+    // measurement update
+    filter->k = filter->p / (filter->p + filter->r);
+    filter->x = filter->x * (1 - filter->k) +  filter->k * input;
+    filter->p = (1.0f - filter->k) * filter->p;
+
+    return filter->x;
+}

--- a/src/main/common/filter.h
+++ b/src/main/common/filter.h
@@ -100,6 +100,7 @@ void biquadRCFIR2FilterInit(biquadFilter_t *filter, float f_cut, float dT);
 
 void fastKalmanInit(fastKalman_t *filter, float q, float r, float p);
 float fastKalmanUpdate(fastKalman_t *filter, float input);
+float fastKalmanUpdate2(fastKalman_t *filter, float input);
 
 // not exactly correct, but very very close and much much faster
 #define filterGetNotchQApprox(centerFreq, cutoff)   ((float)(cutoff * centerFreq) / ((float)(centerFreq - cutoff) * (float)(centerFreq + cutoff)))

--- a/src/test/unit/bqrc_kalman_unittest.cc
+++ b/src/test/unit/bqrc_kalman_unittest.cc
@@ -12,11 +12,13 @@ extern "C" {
 #define M_PI_FLOAT 3.14159265358979323846f
 
 fastKalman_t fkfFilter;
+fastKalman_t fkfFilter2;
 biquadFilter_t bqrcFilter;
 
 TEST(BQRCKalmanTest, BQRCKalmanTest)
 {
     float kalmanOut;
+    float kalmanOut2;
     float bqrcOut;
     uint16_t randVal;
     uint16_t q = 300;
@@ -28,21 +30,24 @@ TEST(BQRCKalmanTest, BQRCKalmanTest)
     float bqrcK = 2.0f * sqrt(bqrcQ) / (sqrt(bqrcQ + 4.0f * bqrcR) + sqrt(bqrcQ));
     float f_cut = 1.0f / (2.0f * M_PI_FLOAT * (0.5f * dT * ((1.0f / bqrcK) - 2.0f)));
     fastKalmanInit(&fkfFilter, q, r, p);
+    fastKalmanInit(&fkfFilter2, q, r, p);
     biquadRCFIR2FilterInit(&bqrcFilter, f_cut, dT);
 
     srand(time(NULL));
     for (int i=1; i <= 500; i++) {
         randVal = rand() % 2000;
         kalmanOut = fastKalmanUpdate(&fkfFilter, (float)randVal);
+        kalmanOut2 = fastKalmanUpdate2(&fkfFilter2, (float)randVal);
         bqrcOut = biquadFilterApply(&bqrcFilter, (float)randVal);
-        printf("Input Value: %4d --- FKF K: %.10f --- FKF: %15.10f --- BQRC: %15.10f\n", randVal, fkfFilter.k, kalmanOut, bqrcOut);
+        printf("Input Value: %4d --- FKF K: %.10f --- FKF: %15.10f --- FKF2 K: %.10f --- FKF2: %15.10f --- BQRC: %15.10f\n", randVal, fkfFilter.k, kalmanOut, fkfFilter2.k, kalmanOut2, bqrcOut);
     }
-    printf ("-------------------\nK :: FKF: %.10f -- BQRC: %.10f\n", fkfFilter.k, bqrcFilter.b0 * 2.0f);
+    printf ("-------------------\nK :: FKF: %.10f -- FKF2: %.10f -- BQRC: %.10f\n", fkfFilter.k, fkfFilter2.k, bqrcFilter.b0 * 2.0f);
 }
 
 TEST(BQRCKalmanTest, BQRCKalmanTestKalmanK)
 {
     float kalmanOut;
+    float kalmanOut2;
     float bqrcOut;
     uint16_t randVal;
     uint16_t q = 300;
@@ -63,8 +68,9 @@ TEST(BQRCKalmanTest, BQRCKalmanTestKalmanK)
         bqrcFilter.b0 = fkfFilter.k;
         bqrcFilter.b1 = fkfFilter.k;
         bqrcFilter.a1 = -(1.0f - fkfFilter.k * 2.0f);
+        kalmanOut2 = fastKalmanUpdate2(&fkfFilter2, (float)randVal);
         bqrcOut = biquadFilterApply(&bqrcFilter, (float)randVal);
-        printf("Input Value: %4d --- FKF K: %.10f --- FKF: %15.10f --- BQRC: %15.10f\n", randVal, fkfFilter.k, kalmanOut, bqrcOut);
+        printf("Input Value: %4d --- FKF K: %.10f --- FKF: %15.10f --- FKF2 K: %.10f --- FKF2: %15.10f --- BQRC: %15.10f\n", randVal, fkfFilter.k, kalmanOut, fkfFilter2.k, kalmanOut2, bqrcOut);
     }
-    printf ("-------------------\nK :: FKF: %.10f -- BQRC: %.10f\n", fkfFilter.k, bqrcFilter.b0 * 2.0f);
+    printf ("-------------------\nK :: FKF: %.10f -- FKF2: %.10f -- BQRC: %.10f\n", fkfFilter.k, fkfFilter2.k, bqrcFilter.b0 * 2.0f);
 }


### PR DESCRIPTION
This PR adds a non-FMA (fused multiply-add) form of Kalman prediction update, showing that the resulting float value may be affected even by this trivial change.
FKF is equal FKF!